### PR TITLE
feat: support arrays of callbacks

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@ import { Request, Response, RequestHandler } from 'express'
 import { MockResponse, RequestOptions } from 'node-mocks-http'
 
 declare function expressRequestMock(
-  callback: RequestHandler,
+  callback: RequestHandler | Array<RequestHandler>,
   options?: RequestOptions,
   decorators?: Record<string, unknown>
 ): Promise<{

--- a/package-lock.json
+++ b/package-lock.json
@@ -3413,17 +3413,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/tap/node_modules/@babel/helper-member-expression-to-functions": {
-      "version": "7.16.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/tap/node_modules/@babel/helper-module-imports": {
       "version": "7.16.7",
       "dev": true,
@@ -3455,36 +3444,11 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/tap/node_modules/@babel/helper-optimise-call-expression": {
-      "version": "7.16.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/tap/node_modules/@babel/helper-plugin-utils": {
       "version": "7.16.7",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/tap/node_modules/@babel/helper-replace-supers": {
-      "version": "7.16.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-member-expression-to-functions": "^7.16.0",
-        "@babel/helper-optimise-call-expression": "^7.16.0",
-        "@babel/traverse": "^7.16.0",
-        "@babel/types": "^7.16.0"
-      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -4496,11 +4460,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/tap/node_modules/minimist": {
-      "version": "1.2.5",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/tap/node_modules/minipass": {
       "version": "3.1.6",
@@ -8028,13 +7987,6 @@
             "@babel/types": "^7.16.7"
           }
         },
-        "@babel/helper-member-expression-to-functions": {
-          "version": "7.16.0",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.16.0"
-          }
-        },
         "@babel/helper-module-imports": {
           "version": "7.16.7",
           "bundled": true,
@@ -8058,27 +8010,10 @@
             "@babel/types": "^7.17.0"
           }
         },
-        "@babel/helper-optimise-call-expression": {
-          "version": "7.16.0",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.16.0"
-          }
-        },
         "@babel/helper-plugin-utils": {
           "version": "7.16.7",
           "bundled": true,
           "dev": true
-        },
-        "@babel/helper-replace-supers": {
-          "version": "7.16.0",
-          "dev": true,
-          "requires": {
-            "@babel/helper-member-expression-to-functions": "^7.16.0",
-            "@babel/helper-optimise-call-expression": "^7.16.0",
-            "@babel/traverse": "^7.16.0",
-            "@babel/types": "^7.16.0"
-          }
         },
         "@babel/helper-simple-access": {
           "version": "7.17.7",
@@ -8726,10 +8661,6 @@
           "requires": {
             "brace-expansion": "^1.1.7"
           }
-        },
-        "minimist": {
-          "version": "1.2.5",
-          "dev": true
         },
         "minipass": {
           "version": "3.1.6",


### PR DESCRIPTION
Express supports arrays of middleware - `router.use([mw1, mw2], mw3)` is identical to `router.use(mw1, mw2, mw3)`.
This behaviour is pretty obscure and I doubt most people use it, but I've found a neat use case for it in something I'm working on.

I think it's worthwhile to add this functionality into this library, maybe?

*****

This PR adds support for `expressRequestMock([mw1, mw2, mw3])`, by rejecting if any fail, or continuing to call if they do.
